### PR TITLE
docs: standardize README section structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,17 @@ php artisan vendor:publish --tag="filament-service-desk-translations"
 composer test
 ```
 
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## Security Vulnerabilities
+
+Please see [SECURITY](.github/SECURITY.md) for details.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds missing Changelog and Security Vulnerabilities sections to match the standard template (same fix as the 3.x PR)