### PR TITLE
docs: standardize README section structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
+## Security Vulnerabilities
+
+Please see [SECURITY](.github/SECURITY.md) for details.
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE) for more information.


### PR DESCRIPTION
## Summary
- Adds missing Security Vulnerabilities section to match the standard template (same fix as the 3.x PR)